### PR TITLE
Replaced run-shell-command

### DIFF
--- a/mclide/src/ccl-frontend/autostart.lisp
+++ b/mclide/src/ccl-frontend/autostart.lisp
@@ -19,7 +19,7 @@
                       :logfile (logfile name)
                       :portfile (full-pathname portfile)))
          #+ignore (asdf::*VERBOSE-OUT* mclide::*log*))
-    (asdf::run-shell-command "(~S -L ~S -e ~S)&" path loader initform)
+    (uiop:run-program (format nil "(~S -L ~S -e ~S)&" path loader initform))
     portfile))
 
 (defmethod reset-from-portfile ((application remote::remote-application) portfile)


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```